### PR TITLE
Identified issue with respawn timers

### DIFF
--- a/src/main/java/fr/black_eyes/lootchest/Lootchest.java
+++ b/src/main/java/fr/black_eyes/lootchest/Lootchest.java
@@ -348,7 +348,7 @@ public class Lootchest {
 		long tempsactuel = (new Timestamp(System.currentTimeMillis())).getTime();
 		long minutes = getTime()*60*1000;
 		long tempsenregistre = getLastreset();
-		return (tempsactuel - tempsenregistre > minutes && minutes>-1);
+		return (tempsactuel - tempsenregistre > minutes);
 	}
 
 	/**

--- a/src/main/java/fr/black_eyes/lootchest/Main.java
+++ b/src/main/java/fr/black_eyes/lootchest/Main.java
@@ -246,7 +246,7 @@ public class Main extends JavaPlugin {
 			logInfo("Chests will load in "+ cooldown + " seconds.");
     	
         this.getServer().getScheduler().runTaskLater(this, new Runnable() {
-            @SuppressWarnings("deprecation")
+
 			@Override
             public void run() {
 		    	logInfo("Loading chests...");
@@ -271,19 +271,22 @@ public class Main extends JavaPlugin {
 				logInfo("Loaded "+lootChest.size() + " Lootchests in "+((new Timestamp(System.currentTimeMillis())).getTime()-current) + " miliseconds");
 				logInfo("Starting LootChest timers asynchronously...");
 				for (final Lootchest lc : lootChest.values()) {
-		            Bukkit.getScheduler().scheduleAsyncDelayedTask(instance, () -> 
-		                    Bukkit.getScheduler().scheduleSyncDelayedTask(instance, () -> {
-		                    		if (!lc.spawn(false)) {
+					new BukkitRunnable() {
+						@Override
+						public void run() {
+							new BukkitRunnable() {
+								@Override
+								public void run() {
+									if (!lc.spawn(false)) {
 		                                Utils.sheduleRespawn(lc);
 										utils.reactivateEffects(lc);
 		                            }
-
-
-		                    }, 0L)
-		            , 5L);
+								}
+							}.runTask(instance);
+						}
+					}.runTaskLaterAsynchronously(instance, 5);
 		        }
 		    	logInfo("Plugin loaded");
-            
 	        }
 	    }, cooldown+1 * 20);
 	}

--- a/src/main/java/fr/black_eyes/lootchest/Utils.java
+++ b/src/main/java/fr/black_eyes/lootchest/Utils.java
@@ -102,7 +102,7 @@ public class Utils  {
 	
 
 	
-	//cr§er le coffe et enregistrer les infos
+	//crï¿½er le coffe et enregistrer les infos
 	//chest creation and registering
 
 	
@@ -175,6 +175,8 @@ public class Utils  {
 		if(time_to_wait<0) {
 			time_to_wait = 30;
 		}
+
+		time_to_wait += 5;
 
 		new BukkitRunnable() {       
             @Override

--- a/src/main/java/fr/black_eyes/lootchest/commands/LootchestCommand.java
+++ b/src/main/java/fr/black_eyes/lootchest/commands/LootchestCommand.java
@@ -11,7 +11,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.InventoryHolder;
-
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -60,7 +60,6 @@ public class LootchestCommand implements CommandExecutor, TabCompleter  {
 			utils = main.getUtils();
 	 }
 	 
-	@SuppressWarnings("deprecation")
 	@Override
 	public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 			String cheststr = "[Chest]";
@@ -237,12 +236,17 @@ public class LootchestCommand implements CommandExecutor, TabCompleter  {
 				else if(args[0].equalsIgnoreCase("respawnall")) {
 		
 					for (final Lootchest l : Main.getInstance().getLootChest().values()) {
-			            Bukkit.getScheduler().scheduleAsyncDelayedTask(Main.getInstance(), () -> {
-			                    Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
-			                    	l.spawn( true) ;
-
-			                    }, 0L);
-			            }, 5L);
+						new BukkitRunnable() {
+							@Override
+							public void run() {
+								new BukkitRunnable() {
+									@Override
+									public void run() {
+										l.spawn( true) ;
+									}
+								}.runTask(Main.getInstance());;
+							}
+						}.runTaskLaterAsynchronously(Main.getInstance(), 5);
 			        }
 					
 					if(Main.configs.NOTE_allcmd_e ) {
@@ -283,16 +287,20 @@ public class LootchestCommand implements CommandExecutor, TabCompleter  {
 					
 					for (final Lootchest l : Main.getInstance().getLootChest().values()) {
 						if(Utils.isWorldLoaded(l.getWorld())) {
-				            Bukkit.getScheduler().scheduleAsyncDelayedTask(Main.getInstance(), () -> {
-				                    Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
-	        							if (!l.spawn( false)) {
-	        								Utils.sheduleRespawn(l);
-											utils.reactivateEffects(l);
-	        							}
-	        							
-	
-				                    }, 0L);
-				            }, 5L);
+							new BukkitRunnable() {
+								@Override
+								public void run() {
+									new BukkitRunnable() {
+										@Override
+										public void run() {
+											if (!l.spawn( false)) {
+												Utils.sheduleRespawn(l);
+												utils.reactivateEffects(l);
+											}
+										}
+									}.runTask(Main.getInstance());
+								}
+							}.runTaskLaterAsynchronously(Main.getInstance(), 5);
 						}
 					}
 					Utils.msg(sender, "PluginReloaded", " ", " ");


### PR DESCRIPTION
Hello, I have identified issue with respawn timers and updated deprecated Bucket AsyncDelayedTasks.

## The issue with timers
### Current State
When a chest is scheduled to respawn in `Utils.copychest` method, exact time to respawn _X_ is calculated (in seconds). Then a task is scheduled to run in exactly _X_ * 20 ticks and it runs `lc.spawn(false);`.
One of the checks that function does is running `Lootchest.checkIfTimeToRespawn` method. However this check calculates time to respawn again, this time let's call it _Y_. 
The issue is that _X_ ends up being a tiny bit smaller than _Y_, so the checkIfTimeToRespawn will fail most of the times.
I don't exactly know what the issue is, but I suspect that it might have something to do with server ticks and the task being scheduled too early. There might possibly even be a rounding error as respawn timers are set in seconds but are calculated later with a bigger precision - milliseconds.

### My fix
I have added 5 additional seconds to __X__, so that the scheduled task with `lc.spawn(false)` runs a bit later. This results in `Lootchest.checkIfTimeToRespawn` never failing and chests keep respawning.

Honestly, I don't think my fix of adding 5 seconds is good enough to be a proper fix. My intention is to explain the issue, so that someone more experienced with plugin development can fix it properly, without having to spend too much time identifying it.
