### PR TITLE
Fix despawnall command not recognizing argument as world

### DIFF
--- a/src/main/java/fr/black_eyes/lootchest/commands/LootchestCommand.java
+++ b/src/main/java/fr/black_eyes/lootchest/commands/LootchestCommand.java
@@ -70,7 +70,7 @@ public class LootchestCommand implements CommandExecutor, TabCompleter  {
 			if (args.length > 0 && !hasPerm(sender, args[0])) {
 				return false;
 			}
-			if (args.length>1 && !Main.getInstance().getLootChest().containsKey(args[1]) && !args[0].equalsIgnoreCase("create") && !args[0].equalsIgnoreCase("respawnall")){
+			if (args.length>1 && !Main.getInstance().getLootChest().containsKey(args[1]) && !args[0].equalsIgnoreCase("create") && !args[0].equalsIgnoreCase("respawnall") && !args[0].equalsIgnoreCase("despawnall")){
 				Utils.msg(sender, "chestDoesntExist", cheststr, args[1]);
 				return false;
 			}else if(args.length>1 && !args[0].equalsIgnoreCase("create")){


### PR DESCRIPTION
When using the command `/lc despawnall <world>`, the plugin would think the world name was a chest and so wouldn't continue execution. Now, it properly accepts a world name as an argument.

I haven't been able to test this change because I don't have the time right now to set up a Java build environment... but reading through the rest of the file, I would guess that this works alright.